### PR TITLE
fix: await (only) async functions

### DIFF
--- a/src/publish.js
+++ b/src/publish.js
@@ -32,7 +32,7 @@ export const queue = new PQueue({ concurrency: CONCURRENCY })
  * @param {string} b64record Base 64 encoded serialized IPNS record.
  * @returns {undefined}
  */
-export async function addToQueue (key, value, b64record) {
+export function addToQueue (key, value, b64record) {
   const keyLog = log.extend(shorten(key))
   keyLog.enabled = true
 
@@ -71,7 +71,7 @@ export async function addToQueue (key, value, b64record) {
       const data = taskData.get(key)
       if (!data) throw new Error('missing task data')
       taskData.delete(key)
-      publishRecord(key, data.value, data.b64record)
+      await publishRecord(key, data.value, data.b64record)
     } finally {
       runningTasks.delete(key)
     }


### PR DESCRIPTION
@joshJarr mentioned that @francois-potato had seen that items which got added to the queue always seemed to run immediately, as if maybe it was operating on a last-in-first-out basis, or it wasn't waiting for things to finish before running the next task.

I think that the missing `await` on `publishRecord()` might explain it, as that would have caused the task to return almost immediately, leaving the promise to resolve in the background. It would still have been working, but the queue would have been ineffective, as new tasks would continue to be added in the mistaken belief that previous tasks had finished.

The `addToQueue` function doesn't need to be async; it doesn't do any asyncy stuff.